### PR TITLE
Add Context to all functions

### DIFF
--- a/gofsutil.go
+++ b/gofsutil.go
@@ -24,9 +24,9 @@ func GetDiskFormat(ctx context.Context, disk string) (string, error) {
 func FormatAndMount(
 	ctx context.Context,
 	source, target, fsType string,
-	options ...string) error {
+	opts ...string) error {
 
-	return fs.FormatAndMount(ctx, source, target, fsType, options...)
+	return fs.FormatAndMount(ctx, source, target, fsType, opts...)
 }
 
 // Mount mounts source to target as fstype with given options.
@@ -38,19 +38,27 @@ func FormatAndMount(
 // The 'options' parameter is a list of options. Please see mount(8) for
 // more information. If no options are required then please invoke Mount
 // with an empty or nil argument.
-func Mount(source, target, fsType string, options ...string) error {
-	return fs.Mount(source, target, fsType, options...)
+func Mount(
+	ctx context.Context,
+	source, target, fsType string,
+	opts ...string) error {
+
+	return fs.Mount(ctx, source, target, fsType, opts...)
 }
 
 // BindMount behaves like Mount was called with a "bind" flag set
 // in the options list.
-func BindMount(source, target string, options ...string) error {
-	return fs.BindMount(source, target, options...)
+func BindMount(
+	ctx context.Context,
+	source, target string,
+	opts ...string) error {
+
+	return fs.BindMount(ctx, source, target, opts...)
 }
 
 // Unmount unmounts the target.
-func Unmount(target string) error {
-	return fs.Unmount(target)
+func Unmount(ctx context.Context, target string) error {
+	return fs.Unmount(ctx, target)
 }
 
 // GetMounts returns a slice of all the mounted filesystems.
@@ -78,7 +86,7 @@ func GetDevMounts(ctx context.Context, dev string) ([]Info, error) {
 // EvalSymlinks evaluates the provided path and updates it to remove
 // any symlinks in its structure, replacing them with the actual path
 // components.
-func EvalSymlinks(symPath *string) error {
+func EvalSymlinks(ctx context.Context, symPath *string) error {
 	realPath, err := filepath.EvalSymlinks(*symPath)
 	if err != nil {
 		return err

--- a/gofsutil_fs.go
+++ b/gofsutil_fs.go
@@ -11,7 +11,6 @@ type FS struct {
 
 // GetDiskFormat uses 'lsblk' to see if the given disk is unformatted.
 func (fs *FS) GetDiskFormat(ctx context.Context, disk string) (string, error) {
-
 	return fs.getDiskFormat(ctx, disk)
 }
 
@@ -21,7 +20,7 @@ func (fs *FS) FormatAndMount(
 	source, target, fsType string,
 	options ...string) error {
 
-	return fs.formatAndMount(ctx, source, target, fsType, options)
+	return fs.formatAndMount(ctx, source, target, fsType, options...)
 }
 
 // Mount mounts source to target as fstype with given options.
@@ -33,24 +32,32 @@ func (fs *FS) FormatAndMount(
 // The 'options' parameter is a list of options. Please see mount(8) for
 // more information. If no options are required then please invoke Mount
 // with an empty or nil argument.
-func (fs *FS) Mount(source, target, fsType string, options ...string) error {
-	return fs.mount(source, target, fsType, options)
+func (fs *FS) Mount(
+	ctx context.Context,
+	source, target, fsType string,
+	options ...string) error {
+
+	return fs.mount(ctx, source, target, fsType, options...)
 }
 
 // BindMount behaves like Mount was called with a "bind" flag set
 // in the options list.
-func (fs *FS) BindMount(source, target string, options ...string) error {
+func (fs *FS) BindMount(
+	ctx context.Context,
+	source, target string,
+	options ...string) error {
+
 	if options == nil {
 		options = []string{"bind"}
 	} else {
 		options = append(options, "bind")
 	}
-	return fs.mount(source, target, "", options)
+	return fs.mount(ctx, source, target, "", options...)
 }
 
 // Unmount unmounts the target.
-func (fs *FS) Unmount(target string) error {
-	return fs.unmount(target)
+func (fs *FS) Unmount(ctx context.Context, target string) error {
+	return fs.unmount(ctx, target)
 }
 
 // GetMounts returns a slice of all the mounted filesystems.

--- a/gofsutil_mount.go
+++ b/gofsutil_mount.go
@@ -238,7 +238,11 @@ func ReadProcMountsFrom(
 // The argument list returned is built as follows:
 //
 //         mount [-t $fsType] [-o $options] [$source] $target
-func MakeMountArgs(source, target, fsType string, opts []string) []string {
+func MakeMountArgs(
+	ctx context.Context,
+	source, target, fsType string,
+	opts ...string) []string {
+
 	args := []string{}
 	if len(fsType) > 0 {
 		args = append(args, "-t", fsType)

--- a/gofsutil_mount_darwin.go
+++ b/gofsutil_mount_darwin.go
@@ -34,7 +34,7 @@ func (fs *FS) getDiskFormat(ctx context.Context, disk string) (string, error) {
 func (fs *FS) formatAndMount(
 	ctx context.Context,
 	source, target, fsType string,
-	options []string) error {
+	opts ...string) error {
 
 	return ErrNotImplemented
 }
@@ -89,6 +89,9 @@ func (fs *FS) getMounts(ctx context.Context) ([]Info, error) {
 }
 
 // bindMount performs a bind mount
-func (fs *FS) bindMount(source, target string, options []string) error {
-	return fs.doMount("bindfs", source, target, "", options)
+func (fs *FS) bindMount(
+	ctx context.Context,
+	source, target string, opts ...string) error {
+
+	return fs.doMount(ctx, "bindfs", source, target, "", opts...)
 }

--- a/gofsutil_mount_linux.go
+++ b/gofsutil_mount_linux.go
@@ -64,19 +64,19 @@ func (fs *FS) getDiskFormat(ctx context.Context, disk string) (string, error) {
 func (fs *FS) formatAndMount(
 	ctx context.Context,
 	source, target, fsType string,
-	options []string) error {
+	opts ...string) error {
 
-	options = append(options, "defaults")
+	opts = append(opts, "defaults")
 	f := log.Fields{
 		"source":  source,
 		"target":  target,
 		"fsType":  fsType,
-		"options": options,
+		"options": opts,
 	}
 
 	// Try to mount the disk
 	log.WithFields(f).Info("attempting to mount disk")
-	mountErr := fs.mount(source, target, fsType, options)
+	mountErr := fs.mount(ctx, source, target, fsType, opts...)
 	if mountErr == nil {
 		return nil
 	}
@@ -111,7 +111,7 @@ func (fs *FS) formatAndMount(
 		// the disk has been formatted successfully try to mount it again.
 		log.WithFields(f).Info(
 			"disk successfully formatted")
-		return fs.mount(source, target, fsType, options)
+		return fs.mount(ctx, source, target, fsType, opts...)
 	}
 
 	// Disk is already formatted and failed to mount
@@ -127,12 +127,16 @@ func (fs *FS) formatAndMount(
 }
 
 // bindMount performs a bind mount
-func (fs *FS) bindMount(source, target string, options []string) error {
-	err := fs.doMount("mount", source, target, "", []string{"bind"})
+func (fs *FS) bindMount(
+	ctx context.Context,
+	source, target string,
+	opts ...string) error {
+
+	err := fs.doMount(ctx, "mount", source, target, "", "bind")
 	if err != nil {
 		return err
 	}
-	return fs.doMount("mount", source, target, "", options)
+	return fs.doMount(ctx, "mount", source, target, "", opts...)
 }
 
 // getMounts returns a slice of all the mounted filesystems

--- a/gofsutil_mount_test.go
+++ b/gofsutil_mount_test.go
@@ -19,22 +19,22 @@ func TestBindMount(t *testing.T) {
 		os.RemoveAll(src)
 		t.Fatal(err)
 	}
-	if err := gofsutil.EvalSymlinks(&src); err != nil {
+	if err := gofsutil.EvalSymlinks(context.TODO(), &src); err != nil {
 		os.RemoveAll(tgt)
 		os.RemoveAll(src)
 		t.Fatal(err)
 	}
-	if err := gofsutil.EvalSymlinks(&tgt); err != nil {
+	if err := gofsutil.EvalSymlinks(context.TODO(), &tgt); err != nil {
 		os.RemoveAll(tgt)
 		os.RemoveAll(src)
 		t.Fatal(err)
 	}
 	defer func() {
-		gofsutil.Unmount(tgt)
+		gofsutil.Unmount(context.TODO(), tgt)
 		os.RemoveAll(tgt)
 		os.RemoveAll(src)
 	}()
-	if err := gofsutil.BindMount(src, tgt); err != nil {
+	if err := gofsutil.BindMount(context.TODO(), src, tgt); err != nil {
 		t.Error(err)
 		t.Fail()
 		return

--- a/gofsutil_unix_test.go
+++ b/gofsutil_unix_test.go
@@ -3,6 +3,7 @@
 package gofsutil_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -54,7 +55,8 @@ func TestMountArgs(t *testing.T) {
 		tt := tt
 		t.Run("", func(st *testing.T) {
 			st.Parallel()
-			opts := gofsutil.MakeMountArgs(tt.src, tt.tgt, tt.fst, tt.opts)
+			opts := gofsutil.MakeMountArgs(
+				context.TODO(), tt.src, tt.tgt, tt.fst, tt.opts...)
 			optsStr := strings.Join(opts, " ")
 			if optsStr != tt.result {
 				t.Errorf("Formatting of mount args incorrect, got: %s want: %s",


### PR DESCRIPTION
This patch adds a Go Context as the first parameter of all public functions in order to help future-proof the function signatures.